### PR TITLE
remove accidental (?) use of list context param call

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The following is example usage to verify captcha response.
 
         my $cap = Captcha::noCAPTCHA->new({site_key => "your site key",secret_key => "your secret key"});
         my $cgi = CGI->new;
+        my $captcha_response = $cgi->param('g-captcha-response');
 
-        if ($cap->verify($cgi->param('g-captcha-response',$cgi->address)) {
+        if ($cap->verify($captcha_response',$cgi->address)) {
                 # Process the rest of the form.
         } else {
                 # Tell user he/she needs to prove his/her humanity.

--- a/lib/Captcha/noCAPTCHA.pm
+++ b/lib/Captcha/noCAPTCHA.pm
@@ -88,8 +88,9 @@ The following is example usage to verify captcha response.
 
 	my $cap = Captcha::noCAPTCHA->new({site_key => "your site key",secret_key => "your secret key"});
 	my $cgi = CGI->new;
+	my $captcha_response = $cgi->param('g-captcha-response');
 
-	if ($cap->verify($cgi->param('g-captcha-response',$cgi->address)) {
+	if ($cap->verify($captcha_response',$cgi->address)) {
 		# Process the rest of the form.
 	} else {
 		# Tell user he/she needs to prove his/her humanity.


### PR DESCRIPTION
in documentation / example, as calling it like this:

```
$cap->verify($cgi->param('g-captcha-response'),$cgi->address)
```

means i can inject extra params into your code with this:

```
foo.cgi?g-captcha-response=true&g-captcha-response=1.2.3.4
```

_bang_ i've injected an ip into the verify call and could possibly
bypass certain checks or do things you don't expect. this has been
discussed at length recently in the perl blog-o-sphere and was the
recent topic of a [very poor but with some legitimate points] talk

see the warning in CGI.pm for param in list_context, or a search on
bugzilla CGI / CCC / CGI param in list context will reveal more
