### PR TITLE
Fix incorrect cmp_ok() test; replace with is().

### DIFF
--- a/t/04-render.t
+++ b/t/04-render.t
@@ -13,10 +13,10 @@ my $cap = Captcha::noCAPTCHA->new({
 
 my $expected=<<EOT;
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<div class="g-recaptcha" data-sitekey="fake site key" data-theme="dark"></div>
+<div class="g-recaptcha" data-sitekey="fake site key" data-theme="light"></div>
 EOT
 
-cmp_ok($expected,'cmp',$cap->html,'to make sure no unexpected output changes are made');
+is($cap->html,$expected,'make sure no unexpected output changes are made');
 
 $cap->theme('dark');
 my $text = $cap->html;


### PR DESCRIPTION
The use of cmp_ok($foo,'cmp',$bar) doesn't match correctly. In particular, the cmp operator will return 0 (false) when they match, and -1 or 1 (true) when they are no matched - that's the opposite of what we want.

This replaces that test with a simple is() test, and fixes the incorrect markup.
