### PR TITLE
add response() accessor that returns most recent response

### DIFF
--- a/lib/Captcha/noCAPTCHA.pm
+++ b/lib/Captcha/noCAPTCHA.pm
@@ -26,6 +26,7 @@ sub noscript { return shift->_get_set('noscript',@_); }
 sub api_url { return shift->_get_set('api_url',@_); }
 sub api_timeout { return shift->_get_set('api_timeout',@_); }
 sub errors { return shift->{_attrs}->{errors}; }
+sub response { return shift->{_response}; }
 
 sub html {
 	my ($self) = @_;
@@ -93,6 +94,7 @@ sub _parse_response {
 		$self->{_attrs}->{errors} = ['invalid-json'];
 		return;
 	}
+	$self->{_response} = $json;
 	$self->{_attrs}->{errors} = $json->{'error-codes'};
 	return $json->{success};
 }
@@ -154,6 +156,9 @@ http-tiny-no-response   HTTP::Tiny did not return anything. No further informati
 status-code-DDD         Where DDD is the status code returned from the server.
 no-content-returned     Call was successful, but no content was returned.
 
+=head2 response()
+
+Returns the response hashref for the most recent captcha response.
 
 =head1 FIELD OPTIONS
 

--- a/t/02-parse_response.t
+++ b/t/02-parse_response.t
@@ -37,4 +37,12 @@ ok(not defined $cap->errors);
 ok($cap->_parse_response({success => 1,content => '{"success": true}'}));
 ok(not defined $cap->errors);
 
+ok(defined $cap->response);
+ok(ref $cap->response eq 'HASH');
+# note: can't use is_deeply to compare the response to a hashref because
+# booleans might be blessed JSON::PP::Boolean objects and is_deeply() doesn't
+# like that.
+ok(keys %{ $cap->response } == 1);
+ok($cap->response->{success} == 1);
+
 done_testing();


### PR DESCRIPTION
Hi.

I needed to be able to do Domain Name Validation with noCAPTCHA, which means I need access to the response object that the recaptcha API sends so I can compore the hostname value with what I expected it to be on my end.

To do this I added a response() accessor which gets the parsed JSON response object from the most recent captcha response.